### PR TITLE
Fixed references in documentation to the usage of encode-array/object-elements

### DIFF
--- a/doc.html
+++ b/doc.html
@@ -415,14 +415,15 @@ NIL</pre>
 	<p xmlns="">[Function]<br><a class="none" name="encode-array-elements"><b>encode-array-elements</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">&amp;rest objects</clix:lambda-list></i>
           =&gt;
           <i>result*</i></a><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
-	    Encode <code><i>objects</i></code>, a list of JSON
-	    encodable objects, as the next array elements in the last
-	    JSON array opened with <code><a href="#with-array">WITH-ARRAY</a></code> in
-	    the dynamic context using
-	    <code><a href="#encode-array-element">ENCODE-ARRAY-ELEMENT</a></code>, which must be
-	    applicable to each object in the list
+	    Encode <code><i>objects</i></code>, a series of JSON
+	    encodable objects, as the next array elements in a JSON
+	    array opened with
+	    <code><a href="#with-array">WITH-ARRAY</a></code>. ENCODE-ARRAY-ELEMENTS
+	    uses <code><a href="#encode-array-element">ENCODE-ARRAY-ELEMENT</a></code>, which must
+	    be applicable to each object in the list
 	    (i.e. <code><a href="#encode">ENCODE</a></code> must be defined for each
-	    object type).
+	    object type). Additionally, this must be called within a
+	    valid stream context.
 	  </clix:description></blockquote></p>
 
         <p xmlns="">[Macro]<br><a class="none" name="with-object"><b>with-object</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">() &amp;body body</clix:lambda-list></i>
@@ -433,7 +434,7 @@ NIL</pre>
             <code><a href="#encode-object-element">ENCODE-OBJECT-ELEMENT</a></code> or
             <code><a href="#with-object-element">WITH-OBJECT-ELEMENT</a></code> must be called to
             encode elements to the object.  Must be called within an
-            existing JSON encoder context, see
+            existing JSON encoder
             <code><a href="#with-output">WITH-OUTPUT</a></code> and
             <code><a href="#with-output-to-string*">WITH-OUTPUT-TO-STRING*</a></code>.
           </clix:description></blockquote></p>
@@ -465,10 +466,11 @@ NIL</pre>
 	<p xmlns="">[Function]<br><a class="none" name="encode-object-elements"><b>encode-object-elements</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">&amp;rest elements</clix:lambda-list></i>
           =&gt;
           <i>result*</i></a><blockquote><clix:description xmlns:clix="http://bknr.net/clixdoc">
-	    Encodes <code><i>elements</i></code>, a plist of
-	    key/value pairs, into JSON in the last object opened with
-	    <code><a href="#with-object">WITH-OBJECT</a></code> using
-	    <code><a href="#encode-object-element">ENCODE-OBJECT-ELEMENT</a></code>.
+	    Encodes the parameters into JSON in the last object opened
+	    with <code><a href="#with-object">WITH-OBJECT</a></code> using
+	    <code><a href="#encode-object-element">ENCODE-OBJECT-ELEMENT</a></code>. The parameters
+	    should consist of alternating key/value pairs, and this
+	    must be called within a valid stream context.
 	  </clix:description></blockquote></p>
 
 	<p xmlns="">[Generic function]<br><a class="none" name="encode-slots"><b>encode-slots</b> <i><clix:lambda-list xmlns:clix="http://bknr.net/clixdoc">object</clix:lambda-list></i>

--- a/doc.xml
+++ b/doc.xml
@@ -415,14 +415,15 @@ NIL</pre>
 	  <clix:lambda-list>&amp;rest objects</clix:lambda-list>
 	  <clix:returns>result*</clix:returns>
 	  <clix:description>
-	    Encode <clix:arg>objects</clix:arg>, a list of JSON
-	    encodable objects, as the next array elements in the last
-	    JSON array opened with <clix:ref>WITH-ARRAY</clix:ref> in
-	    the dynamic context using
-	    <clix:ref>ENCODE-ARRAY-ELEMENT</clix:ref>, which must be
-	    applicable to each object in the list
+	    Encode <clix:arg>objects</clix:arg>, a series of JSON
+	    encodable objects, as the next array elements in a JSON
+	    array opened with
+	    <clix:ref>WITH-ARRAY</clix:ref>. ENCODE-ARRAY-ELEMENTS
+	    uses <clix:ref>ENCODE-ARRAY-ELEMENT</clix:ref>, which must
+	    be applicable to each object in the list
 	    (i.e. <clix:ref>ENCODE</clix:ref> must be defined for each
-	    object type).
+	    object type). Additionally, this must be called within a
+	    valid stream context.
 	  </clix:description>
 	</clix:function>
 
@@ -435,7 +436,7 @@ NIL</pre>
             <clix:ref>ENCODE-OBJECT-ELEMENT</clix:ref> or
             <clix:ref>WITH-OBJECT-ELEMENT</clix:ref> must be called to
             encode elements to the object.  Must be called within an
-            existing JSON encoder context, see
+            existing JSON encoder
             <clix:ref>WITH-OUTPUT</clix:ref> and
             <clix:ref>WITH-OUTPUT-TO-STRING*</clix:ref>.
           </clix:description>
@@ -473,10 +474,11 @@ NIL</pre>
 	  <clix:lambda-list>&amp;rest elements</clix:lambda-list>
 	  <clix:returns>result*</clix:returns>
 	  <clix:description>
-	    Encodes <clix:arg>elements</clix:arg>, a plist of
-	    key/value pairs, into JSON in the last object opened with
-	    <clix:ref>WITH-OBJECT</clix:ref> using
-	    <clix:ref>ENCODE-OBJECT-ELEMENT</clix:ref>.
+	    Encodes the parameters into JSON in the last object opened
+	    with <clix:ref>WITH-OBJECT</clix:ref> using
+	    <clix:ref>ENCODE-OBJECT-ELEMENT</clix:ref>. The parameters
+	    should consist of alternating key/value pairs, and this
+	    must be called within a valid stream context.
 	  </clix:description>
 	</clix:function>
 

--- a/encode.lisp
+++ b/encode.lisp
@@ -212,7 +212,7 @@ method is defined."
   (encode object (output-stream *json-output*)))
 
 (defun encode-array-elements (&rest objects)
-  "Encode OBJECTS, a list of JSON encodable object, as array elements."
+  "Encode OBJECTS, a list of JSON encodable objects, as array elements."
   (dolist (object objects)
     (encode-array-element object)))
 


### PR DESCRIPTION
I fixed the references in the documentation to clarify that the encode-array-elements and encode-object-elements take rest parameters. Now that I look at your comments again, it makes more sense how you explained it. So the docs are now up-to-date with the actual implementation.
