### PR TITLE
 Avoid using e notation

### DIFF
--- a/encode.lisp
+++ b/encode.lisp
@@ -50,7 +50,7 @@
 
 (defmethod encode ((object float) &optional (stream *standard-output*))
   (let ((*read-default-float-format* 'double-float))
-    (princ (coerce object 'double-float) stream))
+    (format stream "~F" (coerce object 'double-float)))
   object)
 
 (defmethod encode ((object integer) &optional (stream *standard-output*))


### PR DESCRIPTION
Unlike Lisp and JavaScript, JSON numeral syntax doesn't allow decimal points without decimal digits:

![number](https://cloud.githubusercontent.com/assets/3055134/5315346/99235fb4-7c7c-11e4-9e28-fc83d9acd980.gif)
(from http://www.json.org/fatfree.html)

``` javascript
% node
> 1.e8
100000000
> JSON.parse("[1e8]")
[ 100000000 ]
> JSON.parse("[1.e8]")
SyntaxError: Unexpected token e
```

I think the easiest and safest solution is to prevent YASON from using e notation when encoding floats.
