### PR TITLE
Escape control and non-BMP characters as required by the spec.

### DIFF
--- a/test.lisp
+++ b/test.lisp
@@ -72,6 +72,11 @@
                         (dotimes (i 3)
                           (yason:encode-array-element i)))))))))
 
+(deftest :yason "stream-encode.unicode-string"
+  (test-equal "\"ab\\u0002 cde \\uD834\\uDD1E\""
+              (with-output-to-string (s)
+                (yason:encode (format nil "ab~C cde ~C" (code-char #x02) (code-char #x1d11e)) s))))
+
 (defstruct user name age password)
 
 (defmethod yason:encode ((user user) &optional (stream *standard-output*))


### PR DESCRIPTION
Non-BMP characters must be escaped as a utf-16 surrogate pair, and control
characters must be escaped rather than included directly. This addresses both
issues.

`unicode-char` and `unicode-code` could be removed from the patch, but the
CL spec doesn't actually specify that `char-code` return the unicode codepoint.
These make the intent obvious, and give you a place to conditionalize that if
some implementation bucks the trend. I can remove them if you (don't) like.

This adds the non-BMP entries to `*char-replacements*` too, so they'll get
properly encoded as surrogate pairs. That adds about a 104 million entries to
the table, though, which might cause problems -- recompiling the
`defparameter` form about 8 times seems to reliably exhaust sbcl's heap in my
default slime setup.

closes #41