### PR TITLE
Add space after `:' when encoding with indentation

### DIFF
--- a/encode.lisp
+++ b/encode.lisp
@@ -112,6 +112,9 @@
 (defun encode-key/value (key value stream)
   (encode key stream)
   (write-char #\: stream)
+  (when (and (typep stream 'json-output-stream)
+             (indent stream))
+    (write-char #\space stream))
   (encode value stream))
 
 (defmethod encode ((object hash-table) &optional (stream *standard-output*))

--- a/test.lisp
+++ b/test.lisp
@@ -52,7 +52,22 @@
                                      (with-output-to-string (s)
                                        (yason:encode '(1 2 3)
                                                     (yason:make-json-output-stream s :indent indentation-arg)))))))
-    
+
+(deftest :yason "dom-encoder.object-indentation"
+  (test-equal "{
+  \"foo\": [
+    1
+  ],
+  \"bar\": [
+    2,
+    3
+  ]
+}"
+              (with-output-to-string (s)
+                (yason:encode-alist
+                 '(("foo" 1) ("bar" 2 3))
+                 (yason:make-json-output-stream s :indent 2)))))
+
 (deftest :yason "stream-encoder.basic-array"
   (test-equal "[0,1,2]"
               (with-output-to-string (s)


### PR DESCRIPTION
Add a space after `:` when encoding objects, to be consistant with other JSON libraries in pretty-print mode.