### PR TITLE
Add method to use the ENCODE-OBJECT/ENCODE-SLOTS protocol in ENCODE

### DIFF
--- a/encode.lisp
+++ b/encode.lisp
@@ -446,3 +446,7 @@ LOWERCASE-KEYS? says whether the key should be in lowercase."
   (:method (object)
     (with-object ()
       (yason:encode-slots object))))
+
+(defmethod encode (object &stream stream)
+  (yason:with-output (s)
+    (yason:encode-object o)))


### PR DESCRIPTION
Implements https://github.com/phmarek/yason/issues/66.

The current state of the library makes the incremental encoder a completely different world from ENCODE.
This makes it harder to extend YASON's encoding system because you have to override both ENCODE and
ENCODE-OBJECT-SLOTS. 