### PR TITLE
Support encoding for cmucl's utf-16 strings

### DIFF
--- a/test.lisp
+++ b/test.lisp
@@ -115,11 +115,20 @@
                           (yason:encode-array-element i)))))))))
 
 ;; See "surrogate" test below for CMUCL.
-#+cmucl
 (deftest :yason "stream-encode.unicode-string"
   (test-equal "\"ab\\u0002 cde \\uD834\\uDD1E\""
+	      #-cmucl
               (with-output-to-string (s)
-                (yason:encode (format nil "ab~C cde ~C" (code-char #x02) (code-char #x1d11e)) s))))
+                (yason:encode (format nil "ab~C cde ~C" (code-char #x02) (code-char #x1d11e)) s))
+	      #+cmucl
+              (with-output-to-string (s)
+		;; Cmucl strings are utf-16 so we need to use
+		;; surrogate pairs to represent codepoints outside the
+		;; BMP.
+                (yason:encode (format nil "ab~C cde ~{~C~}"
+				      (code-char #x02)
+				      (multiple-value-list (lisp:surrogates #x1d11e)))
+			      s))))
 
 (defstruct user name age password)
 

--- a/test.lisp
+++ b/test.lisp
@@ -117,18 +117,18 @@
 ;; See "surrogate" test below for CMUCL.
 (deftest :yason "stream-encode.unicode-string"
   (test-equal "\"ab\\u0002 cde \\uD834\\uDD1E\""
-	      #-cmucl
               (with-output-to-string (s)
-                (yason:encode (format nil "ab~C cde ~C" (code-char #x02) (code-char #x1d11e)) s))
-	      #+cmucl
-              (with-output-to-string (s)
-		;; Cmucl strings are utf-16 so we need to use
-		;; surrogate pairs to represent codepoints outside the
-		;; BMP.
-                (yason:encode (format nil "ab~C cde ~{~C~}"
-				      (code-char #x02)
-				      (multiple-value-list (lisp:surrogates #x1d11e)))
-			      s))))
+		(yason:encode
+		 #-cmucl
+		 (format nil "ab~C cde ~C" (code-char #x02) (code-char #x1d11e))
+		 #+cmucl
+		 ;; Cmucl strings are utf-16 so we need to use
+		 ;; surrogate pairs to represent codepoints outside the
+		 ;; BMP.
+                 (format nil "ab~C cde ~{~C~}"
+			 (code-char #x02)
+			 (multiple-value-list (lisp:surrogates #x1d11e)))
+		 s))))
 
 (defstruct user name age password)
 


### PR DESCRIPTION
Yason currently assumes strings can hold any possible unicode codepoint.  But that's not true with cmucl which uses utf-16 encoding for strings.  The following things are needed to allow yason to handle cmucl's strings.

* encode.lisp:
  * Add cmucl-specific `escape-strint-to-stream` to handle cmucl's utf-16 strings; yason was assuming string can hold any codepoint.
* test.lisp:
  * Update test "stream-encode.unicode-string" for cmucl's utf-16 strings.