### PR TITLE
Make true and false symbols customizable.

### DIFF
--- a/encode.lisp
+++ b/encode.lisp
@@ -195,11 +195,17 @@
   (funcall *list-encoder* object stream))
 
 (defmethod encode ((object symbol) &optional (stream *json-output*))
-  (let ((new (funcall *symbol-encoder* object)))
-    ;; We require a string-like output here to ensure that the JSON format stays consistent.
-    (assert (or (stringp new)
-                (raw-json-output-p new)))
-    (encode new stream)))
+  (cond ((eq object true)
+	 (encode 'true stream))
+	((eq object false)
+	 (encode 'false stream))
+	(t
+	 (let ((new (funcall *symbol-encoder* object)))
+	   ;; We require a string-like output here to ensure that the
+	   ;; JSON format stays consistent.
+	   (assert (or (stringp new)
+                       (raw-json-output-p new)))
+	   (encode new stream)))))
 
 (defun encode-symbol-key-error (key)
   (declare (ignore key))

--- a/parse.lisp
+++ b/parse.lisp
@@ -10,6 +10,14 @@
 (defconstant +default-string-length+ 20
   "Default length of strings that are created while reading json input.")
 
+(declaim (type symbol true))
+(defvar true 'true
+  "Symbol representing the JSON value true.")
+
+(declaim (type symbol false))
+(defvar false 'false
+  "Symbol representing the JSON value false.")
+
 (defvar *parse-object-key-fn* #'identity
   "Function to call to convert a key string in a JSON array to a key
   in the CL hash produced.")
@@ -20,7 +28,8 @@
 
 (defvar *parse-json-booleans-as-symbols* nil
   "If set to a true value, JSON booleans will be read as the symbols
-  TRUE and FALSE, not as T and NIL, respectively.")
+  TRUE and FALSE, not as T and NIL, respectively.  The actual symbols
+  can be customized via the TRUE and FALSE special variables.")
 
 (defvar *parse-json-null-as-keyword* nil
   "If set to a true value, JSON nulls will be read as the keyword :NULL, not as NIL.")
@@ -131,8 +140,8 @@
 (defun parse-constant (input)
   (destructuring-bind (expected-string return-value)
       (find (peek-char nil input nil)
-            `(("true" ,(if *parse-json-booleans-as-symbols* 'true t))
-              ("false" ,(if *parse-json-booleans-as-symbols* 'false nil))
+            `(("true" ,(if *parse-json-booleans-as-symbols* true t))
+              ("false" ,(if *parse-json-booleans-as-symbols* false nil))
               ("null"  ,(if *parse-json-null-as-keyword* :null nil)))
             :key (lambda (entry) (aref (car entry) 0))
             :test #'eql)

--- a/test.lisp
+++ b/test.lisp
@@ -262,3 +262,33 @@
 	      #+cmucl
 	      (list (char-code #\a) #xd834 #xdd1e (char-code #\b))
 	      (map 'list #'char-code (yason:parse "\"a\\ud834\\udd1eb\""))))
+
+(deftest :yason "booleans-as-symbols"
+  (let ((yason:*parse-json-booleans-as-symbols* t))
+    (test-equal (yason:parse "true") 'yason:true :test #'eq)
+    (test-equal (yason:parse "false") 'yason:false :test #'eq)
+    (test-equal (yason:parse "true") yason:true :test #'eq)
+    (test-equal (yason:parse "false") yason:false :test #'eq)
+    (let ((yason:true :true)
+	  (yason:false :false))
+      (test-equal (yason:parse "true") :true :test #'eq)
+      (test-equal (yason:parse "false") :false :test #'eq)
+      (test-equal (yason:parse "true") yason:true :test #'eq)
+      (test-equal (yason:parse "false") yason:false :test #'eq)))
+  (labels ((encode-to-string (data)
+	     (with-output-to-string (stream)
+	       (yason:encode data stream))))
+    (test-equal (encode-to-string 'yason:true) "true")
+    (test-equal (encode-to-string 'yason:false) "false")
+    (test-equal (encode-to-string yason:true) "true")
+    (test-equal (encode-to-string yason:false) "false")
+    (let ((yason:true :true)
+	  (yason:false :false))
+      (test-equal (encode-to-string :true) "true")
+      (test-equal (encode-to-string :false) "false")
+      (test-equal (encode-to-string yason:true) "true")
+      (test-equal (encode-to-string yason:false) "false")
+      ;; The symbols ‘true’ and ‘false’ always encode to true and
+      ;; false, no matter how they are bound.
+      (test-equal (encode-to-string 'yason:true) "true")
+      (test-equal (encode-to-string 'yason:false) "false"))))


### PR DESCRIPTION
When parsing JSON booleans as symbols, it would be nice if the symbols can be customized by the user. For example, using the keywords :true and :false instead of the hard-coded symbols yason:true and yason:false respectively.