### PR TITLE
Fixed error about non applicable method of STREAM-LINE-COLUMN when *PRINT-PRETTY* is T on CCL

### DIFF
--- a/doc.xml
+++ b/doc.xml
@@ -72,6 +72,13 @@
       samples.
     </p>
   </clix:chapter>
+  
+  <clix:chapter name="test" title="Running Tests">
+    <p>
+      To run tests, load the system and run this in the REPL:
+      <pre>CL-USER&gt; (asdf:test-system :yason)</pre>
+    </p>
+  </clix:chapter>
 
   <clix:chapter name="json-package" title="Using JSON as package name">
     Versions of YASON preceding the v0.6.0 release provided a package

--- a/encode.lisp
+++ b/encode.lisp
@@ -497,6 +497,6 @@ LOWERCASE-KEYS? says whether the key should be in lowercase."
       (yason:encode-slots object))))
 
 ;; See discussion at https://github.com/phmarek/yason/issues/74
-#+cmucl
+#+(or cmucl ccl)
 (defmethod trivial-gray-streams:stream-line-column ((stream json-output-stream))
   nil)

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 <ol xmlns="">
 <li><a href="#intro">Introduction</a></li>
 <li><a href="#install">Download and Installation</a></li>
+<li><a href="#test">Running Tests</a></li>
 <li><a href="#json-package">Using JSON as package name</a></li>
 <li><a href="#mapping">Mapping between JSON and CL datatypes</a></li>
 <li>
@@ -103,6 +104,13 @@
       access YASON's symbols.  For that reason, YASON's symbols do not
       contain the string "JSON" themselves.  See below for usage
       samples.
+    </p>
+  
+  
+  <h3 xmlns=""><a class="none" name="test">Running Tests</a></h3>
+    <p>
+      To run tests, load the system and run this in the REPL:
+      <pre>CL-USER&gt; (asdf:test-system :yason)</pre>
     </p>
   
 
@@ -303,13 +311,20 @@ CL-USER&gt; (let* ((yason:*parse-json-arrays-as-vectors* t)
         </clix:description></blockquote></p>
 
     
+
+	<p>
+		To avoid <a href="https://bishopfox.com/blog/json-interoperability-vulnerabilities">security issues</a>
+        in Common Lisp code and/or downstream, on parsing JSON duplicate keys
+		are rejected. If allowing that is a real use case, please send a patch
+		providing a restart.
+	</p>
   
 
   <h3 xmlns=""><a class="none" name="encoding">Encoding JSON data</a></h3>
     YASON provides two distinct modes to encode JSON data:
     applications can either create an in-memory representation of the
     data to be serialized, then have YASON convert it to JSON in one
-    go, or they can use a set of macros to serialze the JSON data
+    go, or they can use a set of macros to serialize the JSON data
     element-by-element, allowing fine-grained control over the layout
     of the generated data.
 

--- a/render-doc.sh
+++ b/render-doc.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# To make this script work on Ubuntu, run this command to install required packages:
+# apt install xsltproc libxml2-utils
+
 xmllint --noout doc.xml
 [ -f clixdoc.xsl ] || wget -q https://raw.github.com/hanshuebner/clixdoc/master/clixdoc.xsl
 xsltproc --stringparam current-release `perl -ne 'if (/^ *:version +"(.*)"/) { print "$1\n" }' yason.asd` -o index.html clixdoc.xsl doc.xml 

--- a/test.lisp
+++ b/test.lisp
@@ -44,6 +44,15 @@
     (test-equal (first *basic-test-json-dom*) (first result) :test #'equalp)
     (test-equal (rest *basic-test-json-dom*) (rest result))))
 
+(deftest :yason "dom-encoder.w-o-t-s*-pretty"
+  (let* ((*print-pretty* t)
+         (stg (yason:with-output-to-string* (:indent 2)
+                (yason:encode *basic-test-json-dom*)))
+         (result (yason:parse stg)))
+    (test-equal (subseq stg 2 5) "  {")
+    (test-equal (first *basic-test-json-dom*) (first result) :test #'equalp)
+    (test-equal (rest *basic-test-json-dom*) (rest result))))
+
 (deftest :yason "dom-encoder.w-o"
   (let* ((stg (with-output-to-string (s)
                     (yason:with-output (s :indent 3)

--- a/yason-tests.asd
+++ b/yason-tests.asd
@@ -1,0 +1,11 @@
+(defsystem "yason-tests"
+  :name "YASON"
+  :author "Hans Huebner <hans@huebner.org>"
+  :licence "BSD"
+  :description "Tests for Yason - JSON parser/encoder"
+  :depends-on (:yason :unit-test)
+  :components ((:file "test"))
+  :perform (test-op (o c)
+                    (unless (symbol-call :unit-test '#:run-all-tests
+                                         :unit :yason)
+                      (error "Tests failed"))))

--- a/yason.asd
+++ b/yason.asd
@@ -29,4 +29,5 @@
   :depends-on (:alexandria :trivial-gray-streams)
   :components ((:file "package")
 	       (:file "encode" :depends-on ("package"))
-	       (:file "parse" :depends-on ("package"))))
+	       (:file "parse" :depends-on ("package")))
+  :in-order-to ((test-op (test-op "yason-tests"))))


### PR DESCRIPTION
Also, I've added a test ASDF system and ability to run tests like this:

    (asdf:test-syste :yason)